### PR TITLE
remove deprecated link share methods

### DIFF
--- a/Samples/Catalog/Sources/ShareAPIViewController.swift
+++ b/Samples/Catalog/Sources/ShareAPIViewController.swift
@@ -57,10 +57,7 @@ final class ShareAPIViewController: UITableViewController {
 
 extension ShareAPIViewController {
   @IBAction func shareLink() {
-    let content = LinkShareContent(url: URL(string: "https://newsroom.fb.com/")!,
-                                   title: "Name: Facebook News Room",
-                                   description: "Description: The Facebook Swift SDK helps you develop Facebook integrated iOS apps.",
-                                   imageURL: URL(string: "https://raw.github.com/fbsamples/ios-3.x-howtos/master/Images/iossdk_logo.png"))
+    let content = LinkShareContent(url: URL(string: "https://newsroom.fb.com/")!)
     share(content)
   }
 }

--- a/Samples/Catalog/Sources/ShareDialogViewController.swift
+++ b/Samples/Catalog/Sources/ShareDialogViewController.swift
@@ -42,10 +42,7 @@ final class ShareDialogViewController: UITableViewController {
 
 extension ShareDialogViewController {
   @IBAction func showLinkShareDialogModeAutomatic() {
-    var content = LinkShareContent(url: URL(string: "https://newsroom.fb.com/")!,
-                                   title: "Name: Facebook News Room",
-                                   description: "Description: The Facebook Swift SDK helps you develop Facebook integrated iOS apps.",
-                                   imageURL: URL(string: "https://raw.github.com/fbsamples/ios-3.x-howtos/master/Images/iossdk_logo.png"))
+    var content = LinkShareContent(url: URL(string: "https://newsroom.fb.com/")!)
 
     // placeId is hardcoded here, see https://developers.facebook.com/docs/graph-api/using-graph-api/#search for building a place picker.
     content.placeId = "166793820034304"
@@ -54,10 +51,7 @@ extension ShareDialogViewController {
   }
 
   @IBAction func showLinkShareDialogModeWeb() {
-    var content = LinkShareContent(url: URL(string: "https://newsroom.fb.com/")!,
-                                   title: "Name: Facebook News Room",
-                                   description: "Description: The Facebook Swift SDK helps you develop Facebook integrated iOS apps.",
-                                   imageURL: URL(string: "https://raw.github.com/fbsamples/ios-3.x-howtos/master/Images/iossdk_logo.png"))
+    var content = LinkShareContent(url: URL(string: "https://newsroom.fb.com/")!)
 
     // placeId is hardcoded here, see https://developers.facebook.com/docs/graph-api/using-graph-api/#search for building a place picker.
     content.placeId = "166793820034304"

--- a/Sources/Share/Content/Link/LinkShareContent.swift
+++ b/Sources/Share/Content/Link/LinkShareContent.swift
@@ -26,49 +26,22 @@ public struct LinkShareContent: ContentProtocol {
   public typealias Result = PostSharingResult
 
   /**
-   The title to display for this link.
-
-   This value may be discarded for specially handled links (ex: iTunes URLs).
-   */
-  public var title: String?
-
-  /**
-   The description of the link.
-
-   If not specified, this field is automatically populated by information scraped from the contentURL,
-   typically the title of the page. This value may be discarded for specially handled links (ex: iTunes URLs).
-   */
-  public var description: String?
-
-  /**
    Some quote text of the link.
 
    If specified, the quote text will render with custom styling on top of the link.
    */
   public var quote: String?
 
-  /// The URL of a picture to attach to this content.
-  public var imageURL: URL?
-
   /**
    Create link share content.
 
    - parameter url:         The URL being shared.
-   - parameter title:       Optional title to display for this link.
-   - parameter description: Optional description of the link.
    - parameter quote:       Optional quote text of the link.
-   - parameter imageURL:    OPtional image URL of a picture to attach.
    */
   public init(url: URL,
-              title: String? = nil,
-              description: String? = nil,
-              quote: String? = nil,
-              imageURL: URL? = nil) {
+              quote: String? = nil) {
     self.url = url
-    self.title = title
-    self.description = description
     self.quote = quote
-    self.imageURL = imageURL
   }
 
   //--------------------------------------
@@ -118,9 +91,6 @@ extension LinkShareContent: Equatable {
 extension LinkShareContent: SDKBridgedContent {
   internal var sdkSharingContentRepresentation: FBSDKSharingContent {
     let content = FBSDKShareLinkContent()
-    content.contentDescription = self.description
-    content.contentTitle = self.title
-    content.imageURL = self.imageURL
     content.quote = self.quote
     content.contentURL = self.url
     content.hashtag = self.hashtag?.sdkHashtagRepresentation


### PR DESCRIPTION
removing the above method calls resolves a warning that all apps using FBSDK are now getting.